### PR TITLE
Website name redirect on doc home

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 # Project information
 site_name: Grin Documentation
 site_url: https://docs.grin.mw
-site_main_url: https://grin.mw
+main_site_url: https://grin.mw
+main_site_name: Grin
 site_author: Grin Developers
 site_description: 'Grin Documentation'
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,12 @@
 # Project information
 site_name: Grin Documentation
 site_url: https://docs.grin.mw
-main_site_url: https://grin.mw
-main_site_name: Grin
 site_author: Grin Developers
 site_description: 'Grin Documentation'
+
+# Main site information
+main_site_url: https://grin.mw
+main_site_name: Grin
 
 # Repository
 repo_name: mimblewimble/grin

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -28,10 +28,10 @@
 
     <!-- Link to home -->
     <a
-      href="{{ config.site_main_url | default(nav.homepage.url, true) | url }}"
-      title="{{ config.site_name }}"
+      href="{{ config.main_site_url | default(nav.homepage.url, true) | url }}"
+      title="{{ config.main_site_name }}"
       class="md-header-nav__button md-logo"
-      aria-label="{{ config.site_name }}"
+      aria-label="{{ config.site_main_name }}"
     >
       {% include "partials/logo.html" %}
     </a>
@@ -45,12 +45,24 @@
     <div class="md-header-nav__title" data-md-component="header-title">
       {% if config.site_name == page.title %}
         <div class="md-header-nav__ellipsis md-ellipsis">
-          {{ config.site_name }}
+          <a
+            href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
+            title="{{ config.site_name }}"
+            aria-label="{{ config.site_name }}"
+          >
+            {{ config.site_name }}
+          </a>
         </div>
       {% else %}
         <div class="md-header-nav__ellipsis">
           <span class="md-header-nav__topic md-ellipsis">
-            {{ config.site_name }}
+            <a
+              href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
+              title="{{ config.site_name }}"
+              aria-label="{{ config.site_name }}"
+            >
+              {{ config.site_name }}
+            </a>
           </span>
           <span class="md-header-nav__topic md-ellipsis">
             {% if page and page.meta and page.meta.title %}


### PR DESCRIPTION
Clicking on the website name now redirect to the home of the doc.
Clicking on the logo redirect to main grin website.
Added `main_site_name` in config and rename `site_main_url` to `main_site_url`