### PR TITLE
Remove HBTC & Slight integration guide change

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -8,7 +8,6 @@
 - [Bittrex](https://global.bittrex.com/)
 - [Hotbit](https://www.hotbit.io/)
 - [Gate.io](https://www.gate.io/)
-- [HBTC](https://www.hbtc.com/)
 - [KuCoin](https://www.kucoin.com/)
 - [Kaiserex](https://www.kaiserex.com/)
 - [BigONE](https://big.one/en)


### PR DESCRIPTION
- Remove HBTC exchange from list of services.
- Separate more clearly the Technical Details part of the [Slatepack Integration](https://docs.grin.mw/wiki/services/slatepack-integration/#technical-details) guide by putting it inside an admonition that is open by default. Makes the document less intimidating to read at first glance.
