### PR TITLE
Update active withdraw/deposit exchanges

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -5,14 +5,15 @@
 ### Active trading and withdraw/deposit
 
 - [TradeOgre](https://tradeogre.com/markets)
+- [Gate.io](https://www.gate.io/)
+- [BitForex](https://www.bitforex.com/)
+
 
 ### Active trading but no withdraw/deposit
 
-- [BitForex](https://www.bitforex.com/)
 - [HitBTC](https://hitbtc.com/)
 - [Bittrex](https://global.bittrex.com/)
 - [Hotbit](https://www.hotbit.io/)
-- [Gate.io](https://www.gate.io/)
 - [KuCoin](https://www.kucoin.com/)
 - [Kaiserex](https://www.kaiserex.com/)
 - [BigONE](https://big.one/en)


### PR DESCRIPTION
Gate.io & BitForex active again:
- Gate.io supports Grin’s slatepack: https://www.gate.io/en/article/19663
- BitForex supports HTTP only.