### PR TITLE
Update active withdraw/deposit exchanges

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -5,12 +5,11 @@
 ### Active trading and withdraw/deposit
 
 - [TradeOgre](https://tradeogre.com/markets)
-- [Gate.io](https://www.gate.io/)
-- [BitForex](https://www.bitforex.com/)
-
 
 ### Active trading but no withdraw/deposit
 
+- [Gate.io](https://www.gate.io/)
+- [BitForex](https://www.bitforex.com/)
 - [HitBTC](https://hitbtc.com/)
 - [Bittrex](https://global.bittrex.com/)
 - [Hotbit](https://www.hotbit.io/)


### PR DESCRIPTION
Gate.io & BitForex wallets inactive again:

## Gate.io:
![image](https://user-images.githubusercontent.com/8020386/112436640-e7401900-8d80-11eb-8c4f-4af29aad9849.png)

## BitForex:
![image](https://user-images.githubusercontent.com/8020386/112436718-06d74180-8d81-11eb-9c24-6510acfefa1e.png)