### PR TITLE
Update list-of-services.md

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -28,3 +28,4 @@
 - [WoolyPooly](https://woolypooly.com)
 - [2Miners](https://2miners.com)
 - [MinerGate](https://minergate.com)
+- [GoblinPool](https://goblinpool.com/)

--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -11,7 +11,6 @@
 - [Gate.io](https://www.gate.io/)
 - [BitForex](https://www.bitforex.com/)
 - [HitBTC](https://hitbtc.com/)
-- [Bittrex](https://global.bittrex.com/)
 - [Hotbit](https://www.hotbit.io/)
 - [KuCoin](https://www.kucoin.com/)
 - [Kaiserex](https://www.kaiserex.com/)
@@ -26,9 +25,6 @@
 ## Mining Pools
 
 - [GrinMint](https://www.grinmint.com)
-- [Sparkpool](https://sparkpool.com)
-- [F2Pool](https://www.f2pool.com)
 - [WoolyPooly](https://woolypooly.com)
-- [BTC.com](https://pool.btc.com)
 - [2Miners](https://2miners.com)
 - [MinerGate](https://minergate.com)

--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -5,10 +5,10 @@
 ### Active trading and withdraw/deposit
 
 - [TradeOgre](https://tradeogre.com/markets)
+- [Gate.io](https://www.gate.io/)
 
 ### Active trading but no withdraw/deposit
 
-- [Gate.io](https://www.gate.io/)
 - [BitForex](https://www.bitforex.com/)
 - [HitBTC](https://hitbtc.com/)
 - [Hotbit](https://www.hotbit.io/)


### PR DESCRIPTION
Remove:
- Bittrex: https://global.bittrex.com/Market/Index?MarketName=BTC-GRIN
- Sparkpool: https://help.sparkpool.com/hc/kb/article/1447546/?lang=en
- F2Pool: https://f2pool.io/mining/updates/
- BTC.com: https://help.pool.btc.com/hc/en-us/articles/900003822746-The-Announcement-on-Offlining-GRIN-BEAM-Mining-Service-of-BTC-com-Pool-