### PR TITLE
Update list of services: Remove GrinMint

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -24,7 +24,6 @@
 
 ## Mining Pools
 
-- [GrinMint](https://www.grinmint.com)
 - [WoolyPooly](https://woolypooly.com)
 - [2Miners](https://2miners.com)
 - [MinerGate](https://minergate.com)


### PR DESCRIPTION
URL: https://grinmint.com/

>### Warning: Pool Termination
> It is with great sadness that we are announcing the end of Grinmint. We are really grateful to the miners and the Grin community for trusting us for more than 2 years.
>
>We encourage miners to switch to another mining pool and withdraw their payouts as soon as possible. Please note the following dates:
>
>**On July 21**, the stratum server will be stopped.
>**On August 7**, the website will be shut down.