### PR TITLE
ci: ignore template pull request link

### DIFF
--- a/.github/workflows/markdown-links.config.json
+++ b/.github/workflows/markdown-links.config.json
@@ -8,6 +8,9 @@
     },
     {
       "pattern": "https://www.hotbit.io/"
+    },
+    {
+      "pattern": "https://github.com/mimblewimble/grin-rfcs/pull/0000"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
Automated markdown link checker should ignore the rfc template PR link so that issues similar to https://github.com/mimblewimble/docs/runs/2839809322#step:5:346 do not happen again.