### PR TITLE
Add instructions for creating a wallet service

### DIFF
--- a/docs/getting-started/quickstart/receive.md
+++ b/docs/getting-started/quickstart/receive.md
@@ -32,6 +32,10 @@ grin-wallet listen
 
 Done! This sets up your wallet to listen for incoming connections through Tor. Just let the sender know that your wallet is ready. You can type `grin-wallet info` to check your wallet balance.
 
+You can make sure your wallet is online by [checking if it's reachable](../../wiki/extra-documents/always-listening-wallet.md#verifying-your-wallet-is-online-and-reachable).
+
+If your wallet should always be online, see [Setting up an always listening wallet](../../wiki/extra-documents/always-listening-wallet.md).
+
 ## Slatepack
 
 Slatepacks are encoded text messages used to transfer the data required to form a transaction, and are an alternative to a hands-off method such as Tor. The messages are easily copy-pasted and can be transferred in any communication channel imaginable: email, forum, social media, chat, letter, carrier pigeon etc.

--- a/docs/wiki/extra-documents/always-listening-wallet.md
+++ b/docs/wiki/extra-documents/always-listening-wallet.md
@@ -1,0 +1,84 @@
+# Setting up an always listening wallet
+
+For some use cases, like mining Grin, it's important to have a wallet that is always listening for incoming transactions. For this use case and others like it, configuring `grin-wallet` as a service is recommended and easy to do.
+
+## Set up grin-wallet as a service
+
+Create a service file for `grin-wallet`:
+
+```bash
+sudo nano /etc/systemd/system/grin-wallet.service
+```
+
+Paste the following content into the file. The following configuration assumes a 'grin' user will be running the process with the wallet configuration living in `/var/lib/grin`. Wallet configuration by default is saved to the user's home directory in `.grin`. If you installed the snap package, your wallet command will be `grin.wallet` instead.
+
+```
+[Unit]
+Description=grin wallet
+After=network.target
+
+[Service]
+WorkingDirectory=/var/lib/grin
+User=grin
+Group=grin
+PrivateDevices=yes
+Type=simple
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=60
+ExecStart=/usr/local/bin/grin-wallet listen
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+Alias=grin.service
+```
+
+Tell systemd to reload (you need to do that every time you edit this file):
+
+```bash
+systemctl daemon-reload
+```
+
+Now try to start the wallet service:
+
+```bash
+sudo systemctl start grin-wallet
+```
+
+And check to see if it's running:
+
+```bash
+ps aux | grep grin-wallet
+```
+
+That should give you two lines of output like this:
+
+```bash
+grin      269149  0.0  0.0 971240 10804 ?        Sl   Aug25   0:00 /usr/local/bin/grin-wallet listen
+ubuntu    336964  0.0  0.0   7004  2168 pts/0    S+   22:02   0:00 grep --color=auto grin-wallet
+```
+
+## Handling a wallet password
+
+If your wallet is configured with a password, the `ExecStart` line in `grin-wallet.service` should probably look something like this...
+
+```bash
+ExecStart=/bin/sh -c 'cat wallet-password.txt | /usr/local/bin/grin-wallet listen'
+```
+
+Drop you wallet's password in `wallet-password.txt`. Make sure this file lives in the configured `WorkingDirectory` and that correct read permissions are set. The contents of this file will be fed into the `grin-wallet` command.
+
+## Verifying your wallet is online and reachable
+
+Run the following command to get your wallet's address:
+
+```bash
+grin-wallet info
+```
+
+Grab the address that is displayed and search for it on [grinchck](https://grinchck.uber.space/)
+
+[More information on grinchck](https://forum.grin.mw/t/is-this-grin-wallet-url-reachable/7349)


### PR DESCRIPTION
Add a brand new wiki page in `extra-documents/` to guide the user
through creating a new Grin wallet service. This guide also covers
handling wallet password authentication as well as verifying that the
wallet is reachable.

Also a few links to this new guide has been added to the `receive.md`
quickstart page.