### PR TITLE
Fixed explorer links

### DIFF
--- a/docs/wiki/services/list-of-services.md
+++ b/docs/wiki/services/list-of-services.md
@@ -12,8 +12,10 @@
 ## Block Explorers
 
 - [Grincoin](https://grincoin.org/)
-- [Grinminer (GRIN TESTNET)]https://testexplorer.grinminer.net/
-
+- [Grincoin Testnet](https://testnet.grincoin.org/)
+- [Grinminer](https://explorer.grinminer.net/)
+- [Grinminer Testnet](https://testexplorer.grinminer.net/)
+- [Grinexplorer](https://grinexplorer.net/)
 
 
 ## Mining Pools


### PR DESCRIPTION
Now it has grincoin.org + grinminer.net's mainnet and testnet explorers. plus I added grinexplorer.net.